### PR TITLE
feat: デザインシステムにPickerコンポーネントを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3668,6 +3668,37 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@react-spectrum/listbox": {
+      "version": "3.15.7",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/listbox/-/listbox-3.15.7.tgz",
+      "integrity": "sha512-+ArV2cp9S7NmboqVUbptzSLcRzVZGkTPlMlQQ41lPzvomd3Tu6eI2hrNlI9Euphq8nBgYYvZrWaNyQPRSQJ13g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/listbox": "^3.14.8",
+        "@react-aria/utils": "^3.30.1",
+        "@react-aria/virtualizer": "^4.1.9",
+        "@react-spectrum/layout": "^3.6.18",
+        "@react-spectrum/progress": "^3.7.19",
+        "@react-spectrum/text": "^3.5.21",
+        "@react-spectrum/utils": "^3.12.8",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/layout": "^4.5.0",
+        "@react-stately/list": "^3.13.0",
+        "@react-stately/virtualizer": "^4.4.3",
+        "@react-types/listbox": "^3.7.3",
+        "@react-types/shared": "^3.32.0",
+        "@spectrum-icons/ui": "^3.6.19",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.2.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@react-spectrum/menu": {
       "version": "3.22.7",
       "resolved": "https://registry.npmjs.org/@react-spectrum/menu/-/menu-3.22.7.tgz",
@@ -3721,6 +3752,37 @@
       },
       "peerDependencies": {
         "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/picker": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/picker/-/picker-3.16.3.tgz",
+      "integrity": "sha512-h7oXYdNA+F9KJGXCrGxMyL2JG+BEWH5ar/V9bbT7CyQhE0HmGuC285bn23kmhgMSidTv+M5fgAOL1PWY6N0Tmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/select": "^3.16.2",
+        "@react-aria/utils": "^3.30.1",
+        "@react-spectrum/button": "^3.17.3",
+        "@react-spectrum/form": "^3.7.18",
+        "@react-spectrum/label": "^3.16.18",
+        "@react-spectrum/listbox": "^3.15.7",
+        "@react-spectrum/overlays": "^5.8.2",
+        "@react-spectrum/progress": "^3.7.19",
+        "@react-spectrum/text": "^3.5.21",
+        "@react-spectrum/utils": "^3.12.8",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/select": "^3.7.1",
+        "@react-types/select": "^3.10.1",
+        "@react-types/shared": "^3.32.0",
+        "@spectrum-icons/ui": "^3.6.19",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.1.4",
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
@@ -15491,6 +15553,7 @@
         "@react-spectrum/filetrigger": "^3.0.17",
         "@react-spectrum/form": "^3.7.18",
         "@react-spectrum/layout": "^3.6.18",
+        "@react-spectrum/picker": "^3.16.3",
         "@react-spectrum/provider": "^3.10.10",
         "@react-spectrum/radio": "^3.7.20",
         "@react-spectrum/switch": "^3.6.5",

--- a/packages/__design-system/.storybook/main.js
+++ b/packages/__design-system/.storybook/main.js
@@ -22,5 +22,19 @@ const config = {
     name: getAbsolutePath('@storybook/react-vite'),
     options: {},
   },
+
+  viteFinal: async (config) => {
+    // React Spectrumコンポーネント（特に@react-spectrum/picker）の内部で
+    // Node.js固有のprocess.envを参照しているため、ブラウザ環境で
+    // "process is not defined" エラーが発生する。
+    // Viteのdefine設定でコンパイル時にprocess.envを安全な値に置換することで
+    // この問題を解決している。
+    config.define = {
+      ...config.define,
+      global: 'globalThis', // Node.jsのglobalオブジェクトをブラウザ対応
+      'process.env': 'globalThis.process?.env || {}', // process.envを安全にpolyfill
+    };
+    return config;
+  },
 };
 export default config;

--- a/packages/__design-system/Components/Forms/Picker.stories.tsx
+++ b/packages/__design-system/Components/Forms/Picker.stories.tsx
@@ -1,0 +1,167 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+
+import React from 'react';
+
+import { Item, Picker, Section } from './index';
+
+/**
+ * https://react-spectrum.adobe.com/react-spectrum/Picker.html
+ */
+const meta: Meta<typeof Picker> = {
+  title: 'Components/Forms/Picker',
+  component: Picker,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    isDisabled: { control: 'boolean' },
+    isRequired: { control: 'boolean' },
+    validationState: { control: 'inline-radio', options: ['valid', 'invalid'] },
+    description: { control: 'text' },
+    errorMessage: { control: 'text' },
+    isQuiet: { control: 'boolean' },
+  },
+  args: {
+    label: 'Choose an option',
+  },
+};
+export default meta;
+
+export const Basic: StoryObj<typeof Picker> = {
+  render: (args) => (
+    <Picker {...args}>
+      <Item key="red">Red</Item>
+      <Item key="orange">Orange</Item>
+      <Item key="yellow">Yellow</Item>
+      <Item key="green">Green</Item>
+      <Item key="blue">Blue</Item>
+      <Item key="purple">Purple</Item>
+    </Picker>
+  ),
+};
+
+export const WithPlaceholder: StoryObj<typeof Picker> = {
+  args: {
+    placeholder: 'Select a color',
+  },
+  render: (args) => (
+    <Picker {...args}>
+      <Item key="red">Red</Item>
+      <Item key="orange">Orange</Item>
+      <Item key="yellow">Yellow</Item>
+      <Item key="green">Green</Item>
+      <Item key="blue">Blue</Item>
+      <Item key="purple">Purple</Item>
+    </Picker>
+  ),
+};
+
+export const Required: StoryObj<typeof Picker> = {
+  args: {
+    isRequired: true,
+    description: 'Please select a color',
+  },
+  render: (args) => (
+    <Picker {...args}>
+      <Item key="red">Red</Item>
+      <Item key="orange">Orange</Item>
+      <Item key="yellow">Yellow</Item>
+      <Item key="green">Green</Item>
+      <Item key="blue">Blue</Item>
+      <Item key="purple">Purple</Item>
+    </Picker>
+  ),
+};
+
+export const WithValidation: StoryObj<typeof Picker> = {
+  args: {
+    validationState: 'invalid',
+    errorMessage: 'Please select a valid option',
+  },
+  render: (args) => (
+    <Picker {...args}>
+      <Item key="red">Red</Item>
+      <Item key="orange">Orange</Item>
+      <Item key="yellow">Yellow</Item>
+      <Item key="green">Green</Item>
+      <Item key="blue">Blue</Item>
+      <Item key="purple">Purple</Item>
+    </Picker>
+  ),
+};
+
+export const WithSections: StoryObj<typeof Picker> = {
+  args: {
+    label: 'Choose an animal',
+  },
+  render: (args) => (
+    <Picker {...args}>
+      <Section title="Mammals">
+        <Item key="dog">Dog</Item>
+        <Item key="cat">Cat</Item>
+        <Item key="elephant">Elephant</Item>
+      </Section>
+      <Section title="Birds">
+        <Item key="eagle">Eagle</Item>
+        <Item key="parrot">Parrot</Item>
+        <Item key="penguin">Penguin</Item>
+      </Section>
+      <Section title="Fish">
+        <Item key="shark">Shark</Item>
+        <Item key="salmon">Salmon</Item>
+        <Item key="tuna">Tuna</Item>
+      </Section>
+    </Picker>
+  ),
+};
+
+export const Disabled: StoryObj<typeof Picker> = {
+  args: {
+    isDisabled: true,
+  },
+  render: (args) => (
+    <Picker {...args}>
+      <Item key="red">Red</Item>
+      <Item key="orange">Orange</Item>
+      <Item key="yellow">Yellow</Item>
+      <Item key="green">Green</Item>
+      <Item key="blue">Blue</Item>
+      <Item key="purple">Purple</Item>
+    </Picker>
+  ),
+};
+
+export const Quiet: StoryObj<typeof Picker> = {
+  args: {
+    isQuiet: true,
+  },
+  render: (args) => (
+    <Picker {...args}>
+      <Item key="red">Red</Item>
+      <Item key="orange">Orange</Item>
+      <Item key="yellow">Yellow</Item>
+      <Item key="green">Green</Item>
+      <Item key="blue">Blue</Item>
+      <Item key="purple">Purple</Item>
+    </Picker>
+  ),
+};
+
+const dynamicItems = [
+  { id: 1, name: 'Apple' },
+  { id: 2, name: 'Banana' },
+  { id: 3, name: 'Orange' },
+  { id: 4, name: 'Strawberry' },
+  { id: 5, name: 'Grapes' },
+];
+
+export const DynamicItems: StoryObj<typeof Picker> = {
+  args: {
+    label: 'Choose a fruit',
+  },
+  render: (args) => (
+    <Picker {...args} items={dynamicItems}>
+      {(item) => <Item key={item.id}>{item.name}</Item>}
+    </Picker>
+  ),
+};

--- a/packages/__design-system/Components/Forms/index.ts
+++ b/packages/__design-system/Components/Forms/index.ts
@@ -1,4 +1,5 @@
 export { Form } from '@react-spectrum/form';
+export { Picker, Item, Section } from '@react-spectrum/picker';
 export { Radio, RadioGroup } from '@react-spectrum/radio';
 export { Switch } from '@react-spectrum/switch';
 export { TextField } from '@react-spectrum/textfield';

--- a/packages/__design-system/package.json
+++ b/packages/__design-system/package.json
@@ -11,6 +11,7 @@
     "@react-spectrum/filetrigger": "^3.0.17",
     "@react-spectrum/form": "^3.7.18",
     "@react-spectrum/layout": "^3.6.18",
+    "@react-spectrum/picker": "^3.16.3",
     "@react-spectrum/provider": "^3.10.10",
     "@react-spectrum/radio": "^3.7.20",
     "@react-spectrum/switch": "^3.6.5",
@@ -27,11 +28,11 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.1",
+    "@storybook/addon-docs": "^9.1.7",
     "@storybook/addon-links": "^9.1.7",
     "@storybook/react-vite": "^9.1.7",
-    "prop-types": "^15.8.1",
-    "storybook": "^9.1.7",
     "eslint-plugin-storybook": "9.1.7",
-    "@storybook/addon-docs": "^9.1.7"
+    "prop-types": "^15.8.1",
+    "storybook": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- Issue #6に対応してデザインシステムにPickerコンポーネントを追加
- React Spectrumの標準Pickerコンポーネントを統合
- 包括的なStorybookストーリーでユースケースを網羅

## 実装内容
- `@react-spectrum/picker`依存関係を追加
- `Components/Forms/index.ts`にPicker関連コンポーネントをエクスポート
- `Picker.stories.tsx`でStorybookストーリーを実装：
  - 基本的な使用例（静的アイテム）
  - プレースホルダー設定
  - 必須フィールド・バリデーション
  - セクション機能（グループ化）
  - 無効・Quietモード
  - 動的アイテム対応

## 技術的修正
- **process.envエラー修正**: Storybook設定でViteのdefineオプションを追加
  - React Spectrumの内部でNode.js固有のprocess.envを参照していたため
  - ブラウザ環境でのpolyfillを設定して`process is not defined`エラーを解決
  - 修正理由をコメントで文書化

## 技術仕様
- React Spectrumの標準APIに準拠
- 既存のデザインシステムパターンに従った実装
- TypeScript型安全性を確保
- ESLint・Prettierルールに準拠

## Test plan
- [x] Storybookで全ストーリーの動作確認
- [x] Pickerコンポーネントのクリック・選択動作確認
- [x] TypeScriptコンパイルエラーなし
- [x] ESLintルール準拠
- [x] 既存コンポーネントとの一貫性確認

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)