### PR TITLE
feat/replace-kitchen-sink-setting-with-framework

### DIFF
--- a/packages/__design-system/Components/Collections/SortDescriptor.ts
+++ b/packages/__design-system/Components/Collections/SortDescriptor.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import { SortDescriptor as _SortDescriptor } from '@react-types/shared/src/collections';
+import reverse from 'lodash/reverse';
+import sortBy from 'lodash/sortBy';
+
+import { isRecord } from '../../utils/TypeUtils';
+
+export type SortDescriptor = _SortDescriptor;
+export const SortDescriptor = {
+  default: (): SortDescriptor => ({
+    column: 0,
+    direction: 'ascending',
+  }),
+  guard: (x: unknown): x is SortDescriptor => {
+    if (!isRecord(x)) {
+      return false;
+    }
+    return isColumnValid(x.column) && isDirectionValid(x.direction);
+  },
+};
+
+const isColumnValid = (x: unknown): x is SortDescriptor['column'] =>
+  x !== undefined && (typeof x === 'string' || typeof x === 'number');
+
+const isDirectionValid = (x: unknown): x is SortDescriptor['direction'] =>
+  x === undefined || x === 'ascending' || x === 'descending';
+
+const usePropsToSort = (initial: SortDescriptor = SortDescriptor.default()) => {
+  const [sortDescriptor, onSortChange] = useState<SortDescriptor>(initial);
+  return {
+    sortDescriptor,
+    onSortChange,
+  };
+};
+
+const toSorted = <T>({
+  items,
+  sortDescriptor,
+}: {
+  items: T[];
+  sortDescriptor: SortDescriptor;
+}): T[] => {
+  const result = sortBy(items, sortDescriptor.column as string);
+  return sortDescriptor.direction === 'descending' ? reverse(result) : result;
+};
+
+export const TableViewUtil = {
+  usePropsToSort,
+  toSorted,
+};

--- a/packages/__design-system/Components/Collections/index.ts
+++ b/packages/__design-system/Components/Collections/index.ts
@@ -23,7 +23,7 @@ const usePropsToSort = (initial: SortDescriptor = SortDescriptor.default()) => {
   };
 };
 
-const toSorted = <T extends object>({
+const toSorted = <T>({
   items,
   sortDescriptor,
 }: {

--- a/packages/__design-system/Components/Collections/index.ts
+++ b/packages/__design-system/Components/Collections/index.ts
@@ -1,40 +1,4 @@
-import { useState } from 'react';
-
-import { SortDescriptor as _SortDescriptor } from '@react-types/shared/src/collections';
-import reverse from 'lodash/reverse';
-import sortBy from 'lodash/sortBy';
-
 export { Cell, Column, Row, TableBody, TableHeader, TableView } from '@react-spectrum/table';
 export type Selection = 'all' | Set<string | number>;
 
-export type SortDescriptor = _SortDescriptor;
-export const SortDescriptor = {
-  default: (): SortDescriptor => ({
-    column: 0,
-    direction: 'ascending',
-  }),
-};
-
-const usePropsToSort = (initial: SortDescriptor = SortDescriptor.default()) => {
-  const [sortDescriptor, onSortChange] = useState<SortDescriptor>(initial);
-  return {
-    sortDescriptor,
-    onSortChange,
-  };
-};
-
-const toSorted = <T>({
-  items,
-  sortDescriptor,
-}: {
-  items: T[];
-  sortDescriptor: SortDescriptor;
-}): T[] => {
-  const result = sortBy(items, sortDescriptor.column as string);
-  return sortDescriptor.direction === 'descending' ? reverse(result) : result;
-};
-
-export const TableViewUtil = {
-  usePropsToSort,
-  toSorted,
-};
+export { SortDescriptor, TableViewUtil } from './SortDescriptor';

--- a/packages/__design-system/hooks/index.ts
+++ b/packages/__design-system/hooks/index.ts
@@ -2,4 +2,4 @@ export { default as useAppEnv } from './useAppEnv';
 export { default as useAppearance, type AppearanceMode } from './useAppearance';
 export { default as useClipboard } from './useClipboard';
 export { default as useFileSelection, DropZoneFileContent } from './useFileSelection';
-export { default as useSetting, type UpdateSetting } from './useSetting';
+export { default as useSetting } from './useSetting';

--- a/packages/__design-system/hooks/useSetting.ts
+++ b/packages/__design-system/hooks/useSetting.ts
@@ -1,6 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import memoize from 'lodash/memoize';
+
+import { isRecord } from '../utils/TypeUtils';
 
 type Setting = Record<string, unknown>;
 
@@ -15,8 +17,124 @@ type UpdateWithUnknown<S extends Setting> = <K extends keyof S = keyof S>(
 
 type UpdateSetting<S extends Setting> = UpdateWithTyped<S> & UpdateWithUnknown<S>;
 
-const useSetting = <S extends Setting>(initialSetting: S) => {
+type PersistenceBridge = {
+  read: (scope: string) => Promise<unknown>;
+  write: (scope: string, value: unknown) => Promise<unknown>;
+  delete?: (scope: string) => Promise<unknown>;
+};
+
+type PersistenceOptions<S extends Setting> = {
+  key: string;
+  guard?: (value: unknown) => value is Partial<S>;
+  storage?: PersistenceBridge;
+};
+
+type UseSettingOptions<S extends Setting> = {
+  persistence?: PersistenceOptions<S>;
+};
+
+const readPersistenceBridge = (): PersistenceBridge | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const bridge = (window as typeof window & { api?: { persistence?: PersistenceBridge } }).api;
+
+  return bridge?.persistence;
+};
+
+const sanitizeStoredValue = <S extends Setting>(
+  stored: unknown,
+  initialSetting: S,
+  guard?: (value: unknown) => value is Partial<S>
+): Partial<S> | undefined => {
+  if (guard) {
+    return guard(stored) ? stored : undefined;
+  }
+
+  if (!isRecord(stored)) {
+    return undefined;
+  }
+
+  const storedRecord = stored as Record<PropertyKey, unknown>;
+  const result: Partial<S> = {};
+
+  (Object.keys(initialSetting) as Array<keyof S>).forEach((key) => {
+    const lookupKey = key as PropertyKey;
+    if (Object.prototype.hasOwnProperty.call(storedRecord, lookupKey)) {
+      result[key] = storedRecord[lookupKey] as S[keyof S];
+    }
+  });
+
+  return result;
+};
+
+const useSetting = <S extends Setting>(initialSetting: S, options: UseSettingOptions<S> = {}) => {
   const [setting, setSetting] = useState(initialSetting);
+  const initialSettingRef = useRef(initialSetting);
+  const isHydratedRef = useRef(false);
+
+  initialSettingRef.current = initialSetting;
+
+  const persistenceKey = options.persistence?.key;
+  const persistenceGuard = options.persistence?.guard;
+  const storage = useMemo(() => {
+    if (!options.persistence) {
+      return undefined;
+    }
+    if (options.persistence.storage) {
+      return options.persistence.storage;
+    }
+    return readPersistenceBridge();
+  }, [options.persistence]);
+
+  useEffect(() => {
+    if (!persistenceKey || !storage) {
+      isHydratedRef.current = true;
+      return;
+    }
+
+    let cancelled = false;
+    isHydratedRef.current = false;
+
+    storage
+      .read(persistenceKey)
+      .then((stored) => {
+        if (cancelled || stored === undefined || stored === null) {
+          return;
+        }
+        const resolved = sanitizeStoredValue<S>(
+          stored,
+          initialSettingRef.current,
+          persistenceGuard
+        );
+        if (resolved) {
+          setSetting((prevState) => ({ ...prevState, ...resolved }));
+        }
+      })
+      .catch((error) => {
+        console.warn('[design-system] 設定の読み込みに失敗しました:', error);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          isHydratedRef.current = true;
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [persistenceKey, persistenceGuard, storage]);
+
+  useEffect(() => {
+    if (!persistenceKey || !storage || !isHydratedRef.current) {
+      return;
+    }
+
+    storage.write(persistenceKey, setting).catch((error) => {
+      console.warn('[design-system] 設定の書き込みに失敗しました:', error);
+    });
+  }, [persistenceKey, setting, storage]);
 
   const updateSetting = useMemo(
     () =>

--- a/packages/__design-system/hooks/useSetting.ts
+++ b/packages/__design-system/hooks/useSetting.ts
@@ -4,21 +4,41 @@ import memoize from 'lodash/memoize';
 
 type Setting = Record<string, unknown>;
 
-export type UpdateSetting<T extends Setting> = <S extends keyof T = keyof T>(
-  key: S
-) => (value: T[S]) => void;
+type UpdateWithTyped<S extends Setting> = <K extends keyof S = keyof S>(
+  key: K
+) => (value: S[K]) => void;
 
-const useSetting = <T extends Setting>(initialSetting: T) => {
+type UpdateWithUnknown<S extends Setting> = <K extends keyof S = keyof S>(
+  key: K,
+  guard: (x: unknown) => x is S[K]
+) => (value: unknown) => void;
+
+type UpdateSetting<S extends Setting> = UpdateWithTyped<S> & UpdateWithUnknown<S>;
+
+const useSetting = <S extends Setting>(initialSetting: S) => {
   const [setting, setSetting] = useState(initialSetting);
-  return useMemo(
-    (): [T, UpdateSetting<T>] => [
-      setting,
-      memoize(<S extends keyof T>(key: S) => (value: T[S]) => {
-        setSetting((prevState) => ({ ...prevState, [key]: value }));
+
+  const updateSetting = useMemo(
+    () =>
+      memoize(<K extends keyof S>(key: K, guard?: (x: unknown) => x is S[K]) => {
+        if (!guard) {
+          return (value: S[K]) => {
+            setSetting((prevState) => ({ ...prevState, [key]: value }));
+          };
+        }
+
+        return (value: unknown) => {
+          if (!guard(value)) {
+            console.warn(`Invalid value for key ${String(key)}: ${value}`);
+            return;
+          }
+          setSetting((prevState) => ({ ...prevState, [key]: value }));
+        };
       }),
-    ],
-    [initialSetting]
+    [setSetting]
   );
+
+  return [setting, updateSetting as UpdateSetting<S>] as const;
 };
 
 export default useSetting;

--- a/packages/__design-system/utils/TypeUtils.ts
+++ b/packages/__design-system/utils/TypeUtils.ts
@@ -1,0 +1,2 @@
+export const isRecord = (x: unknown): x is Record<PropertyKey, unknown> =>
+  typeof x === 'object' && x !== null && !Array.isArray(x);

--- a/packages/__electron/index.ts
+++ b/packages/__electron/index.ts
@@ -1,0 +1,17 @@
+import type { AppearanceAPI } from './src/__extensions/appearance/shared';
+import type { PersistenceAPI } from './src/__extensions/persistence/shared';
+
+type GlobalAPI = {
+  appearance: AppearanceAPI;
+  persistence: PersistenceAPI;
+};
+
+/**
+ * for Client App
+ */
+export const getGlobalAPI = (): GlobalAPI | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  return (window as typeof window & { api: GlobalAPI }).api;
+};

--- a/packages/__electron/src/__extensions/appearance/main.ts
+++ b/packages/__electron/src/__extensions/appearance/main.ts
@@ -1,0 +1,73 @@
+import { BrowserWindow, ipcMain, nativeTheme } from 'electron';
+
+import {
+  APPEARANCE_CHANNELS,
+  type AppearanceChannel,
+  type AppearanceState,
+  type ThemeSource,
+} from './shared';
+
+const getAppearanceState = (): AppearanceState => ({
+  themeSource: nativeTheme.themeSource,
+  shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+  shouldUseHighContrastColors: nativeTheme.shouldUseHighContrastColors,
+  shouldUseInvertedColorScheme: nativeTheme.shouldUseInvertedColorScheme,
+});
+
+const broadcastAppearanceState = () => {
+  const state = getAppearanceState();
+  BrowserWindow.getAllWindows().forEach((window) => {
+    window.webContents.send(APPEARANCE_CHANNELS.changed, state);
+  });
+};
+
+const isValidThemeSource = (value: unknown): value is ThemeSource => {
+  return value === 'system' || value === 'light' || value === 'dark';
+};
+
+let nativeThemeListener: (() => void) | undefined;
+
+const registerAppearanceHandlers = () => {
+  const handleGetState: Parameters<typeof ipcMain.handle>[1] = () => getAppearanceState();
+
+  const handleSetThemeSource: Parameters<typeof ipcMain.handle>[1] = (
+    _event,
+    themeSource: unknown
+  ) => {
+    if (isValidThemeSource(themeSource)) {
+      nativeTheme.themeSource = themeSource;
+      broadcastAppearanceState();
+      return getAppearanceState();
+    }
+
+    return getAppearanceState();
+  };
+
+  ipcMain.handle(APPEARANCE_CHANNELS.getState, handleGetState);
+  ipcMain.handle(APPEARANCE_CHANNELS.setThemeSource, handleSetThemeSource);
+
+  const handleNativeThemeUpdated = () => {
+    broadcastAppearanceState();
+  };
+
+  nativeTheme.on('updated', handleNativeThemeUpdated);
+  nativeThemeListener = () => {
+    nativeTheme.removeListener('updated', handleNativeThemeUpdated);
+  };
+};
+
+const unregisterAppearanceHandlers = () => {
+  (Object.values(APPEARANCE_CHANNELS) as AppearanceChannel[]).forEach((channel) => {
+    if (channel === APPEARANCE_CHANNELS.changed) {
+      return;
+    }
+    if (ipcMain.listenerCount(channel) > 0) {
+      ipcMain.removeHandler(channel);
+    }
+  });
+
+  nativeThemeListener?.();
+  nativeThemeListener = undefined;
+};
+
+export { registerAppearanceHandlers, unregisterAppearanceHandlers };

--- a/packages/__electron/src/__extensions/appearance/preload.ts
+++ b/packages/__electron/src/__extensions/appearance/preload.ts
@@ -1,0 +1,27 @@
+import { electronAPI } from '@electron-toolkit/preload';
+
+import {
+  APPEARANCE_CHANNELS,
+  type AppearanceAPI,
+  type AppearanceState,
+  type ThemeSource,
+} from './shared';
+
+const buildAppearanceAPI = (): AppearanceAPI => {
+  const { ipcRenderer } = electronAPI;
+
+  const subscribe: AppearanceAPI['subscribe'] = (listener) => {
+    const handler = (_event: unknown, state: AppearanceState) => listener(state);
+    ipcRenderer.on(APPEARANCE_CHANNELS.changed, handler);
+    return () => ipcRenderer.removeListener(APPEARANCE_CHANNELS.changed, handler);
+  };
+
+  return {
+    getState: () => ipcRenderer.invoke(APPEARANCE_CHANNELS.getState) as Promise<AppearanceState>,
+    setThemeSource: (themeSource: ThemeSource) =>
+      ipcRenderer.invoke(APPEARANCE_CHANNELS.setThemeSource, themeSource),
+    subscribe,
+  };
+};
+
+export { buildAppearanceAPI };

--- a/packages/__electron/src/__extensions/appearance/shared.ts
+++ b/packages/__electron/src/__extensions/appearance/shared.ts
@@ -1,0 +1,22 @@
+export const APPEARANCE_CHANNELS = {
+  changed: 'appearance:changed',
+  getState: 'appearance:get-state',
+  setThemeSource: 'appearance:set-theme-source',
+} as const;
+
+export type AppearanceChannel = (typeof APPEARANCE_CHANNELS)[keyof typeof APPEARANCE_CHANNELS];
+
+export type ThemeSource = 'system' | 'light' | 'dark';
+
+export type AppearanceState = {
+  themeSource: ThemeSource;
+  shouldUseDarkColors: boolean;
+  shouldUseHighContrastColors: boolean;
+  shouldUseInvertedColorScheme: boolean;
+};
+
+export type AppearanceAPI = {
+  getState: () => Promise<AppearanceState>;
+  setThemeSource: (themeSource: ThemeSource) => Promise<AppearanceState>;
+  subscribe: (listener: (state: AppearanceState) => void) => () => void;
+};

--- a/packages/__electron/src/__extensions/persistence/main.ts
+++ b/packages/__electron/src/__extensions/persistence/main.ts
@@ -1,0 +1,136 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+
+import { app, ipcMain } from 'electron';
+
+import { PERSISTENCE_CHANNELS, type PersistenceChannel } from './shared';
+
+type SettingsRecord = Record<string, unknown>;
+
+const USER_SETTINGS_FILE_NAME = 'user-settings.json';
+
+const isString = (value: unknown): value is string => typeof value === 'string' && value.length > 0;
+
+class UserSettingsStore {
+  private cache: SettingsRecord = {};
+
+  private loaded = false;
+
+  private filePath: string | null = null;
+
+  private async ensureLoaded() {
+    if (this.loaded) {
+      return;
+    }
+
+    const userDataPath = app.getPath('userData');
+    const filePath = join(userDataPath, USER_SETTINGS_FILE_NAME);
+
+    this.filePath = filePath;
+
+    try {
+      const raw = await readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as SettingsRecord;
+      if (parsed && typeof parsed === 'object') {
+        this.cache = parsed;
+      }
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'ENOENT') {
+        console.warn('[electron][persistence] 設定ファイルの読み込みに失敗しました:', err);
+      }
+      this.cache = {};
+    }
+
+    this.loaded = true;
+  }
+
+  private async persist() {
+    if (!this.filePath) {
+      return;
+    }
+
+    const directory = dirname(this.filePath);
+    await mkdir(directory, { recursive: true });
+
+    const payload = JSON.stringify(this.cache, null, 2);
+
+    try {
+      await writeFile(this.filePath, payload, 'utf-8');
+    } catch (error) {
+      console.warn('[electron][persistence] 設定ファイルの書き込みに失敗しました:', error);
+    }
+  }
+
+  async read(scope: string) {
+    await this.ensureLoaded();
+    return this.cache[scope];
+  }
+
+  async write(scope: string, value: unknown) {
+    await this.ensureLoaded();
+    this.cache[scope] = value;
+    await this.persist();
+  }
+
+  async delete(scope: string) {
+    await this.ensureLoaded();
+    if (scope in this.cache) {
+      delete this.cache[scope];
+      await this.persist();
+    }
+  }
+}
+
+const store = new UserSettingsStore();
+
+const validateScope = (scope: unknown): scope is string => {
+  if (!isString(scope)) {
+    console.warn('[electron][persistence] scope が無効です:', scope);
+    return false;
+  }
+  return true;
+};
+
+const registerPersistenceHandlers = () => {
+  const handleRead: Parameters<typeof ipcMain.handle>[1] = async (_event, scope: unknown) => {
+    if (!validateScope(scope)) {
+      return null;
+    }
+    return store.read(scope);
+  };
+
+  const handleWrite: Parameters<typeof ipcMain.handle>[1] = async (
+    _event,
+    scope: unknown,
+    value: unknown
+  ) => {
+    if (!validateScope(scope)) {
+      return false;
+    }
+    await store.write(scope, value);
+    return true;
+  };
+
+  const handleDelete: Parameters<typeof ipcMain.handle>[1] = async (_event, scope: unknown) => {
+    if (!validateScope(scope)) {
+      return false;
+    }
+    await store.delete(scope);
+    return true;
+  };
+
+  ipcMain.handle(PERSISTENCE_CHANNELS.read, handleRead);
+  ipcMain.handle(PERSISTENCE_CHANNELS.write, handleWrite);
+  ipcMain.handle(PERSISTENCE_CHANNELS.delete, handleDelete);
+};
+
+const unregisterPersistenceHandlers = () => {
+  (Object.values(PERSISTENCE_CHANNELS) as PersistenceChannel[]).forEach((channel) => {
+    if (ipcMain.listenerCount(channel) > 0) {
+      ipcMain.removeHandler(channel);
+    }
+  });
+};
+
+export { registerPersistenceHandlers, unregisterPersistenceHandlers };

--- a/packages/__electron/src/__extensions/persistence/preload.ts
+++ b/packages/__electron/src/__extensions/persistence/preload.ts
@@ -1,0 +1,16 @@
+import { electronAPI } from '@electron-toolkit/preload';
+
+import { PERSISTENCE_CHANNELS, type PersistenceAPI } from './shared';
+
+const buildPersistenceAPI = (): PersistenceAPI => {
+  const { ipcRenderer } = electronAPI;
+
+  return {
+    read: (scope: string) => ipcRenderer.invoke(PERSISTENCE_CHANNELS.read, scope),
+    write: (scope: string, value: unknown) =>
+      ipcRenderer.invoke(PERSISTENCE_CHANNELS.write, scope, value),
+    delete: (scope: string) => ipcRenderer.invoke(PERSISTENCE_CHANNELS.delete, scope),
+  };
+};
+
+export { buildPersistenceAPI };

--- a/packages/__electron/src/__extensions/persistence/shared.ts
+++ b/packages/__electron/src/__extensions/persistence/shared.ts
@@ -1,0 +1,13 @@
+export const PERSISTENCE_CHANNELS = {
+  read: 'user-persistence:read',
+  write: 'user-persistence:write',
+  delete: 'user-persistence:delete',
+} as const;
+
+export type PersistenceChannel = (typeof PERSISTENCE_CHANNELS)[keyof typeof PERSISTENCE_CHANNELS];
+
+export type PersistenceAPI = {
+  read: (scope: string) => Promise<unknown>;
+  write: (scope: string, value: unknown) => Promise<boolean>;
+  delete: (scope: string) => Promise<boolean>;
+};

--- a/packages/__electron/src/preload/index.d.ts
+++ b/packages/__electron/src/preload/index.d.ts
@@ -1,25 +1,14 @@
 import { ElectronAPI } from '@electron-toolkit/preload';
 
-type ThemeSource = 'system' | 'light' | 'dark';
-
-type AppearanceState = {
-  themeSource: ThemeSource;
-  shouldUseDarkColors: boolean;
-  shouldUseHighContrastColors: boolean;
-  shouldUseInvertedColorScheme: boolean;
-};
-
-type AppearanceAPI = {
-  getState: () => Promise<AppearanceState>;
-  setThemeSource: (themeSource: ThemeSource) => Promise<AppearanceState>;
-  subscribe: (listener: (state: AppearanceState) => void) => () => void;
-};
+import type { AppearanceAPI } from '../__extensions/appearance/shared';
+import type { PersistenceAPI } from '../__extensions/persistence/shared';
 
 declare global {
   interface Window {
     electron: ElectronAPI;
     api?: {
       appearance?: AppearanceAPI;
+      persistence?: PersistenceAPI;
     };
   }
 }

--- a/packages/__electron/src/preload/index.ts
+++ b/packages/__electron/src/preload/index.ts
@@ -1,37 +1,13 @@
 import { electronAPI } from '@electron-toolkit/preload';
 import { contextBridge } from 'electron';
 
-type ThemeSource = 'system' | 'light' | 'dark';
-
-type AppearanceState = {
-  themeSource: ThemeSource;
-  shouldUseDarkColors: boolean;
-  shouldUseHighContrastColors: boolean;
-  shouldUseInvertedColorScheme: boolean;
-};
-
-const APPEARANCE_CHANNEL = 'appearance:changed';
-
-const buildAppearanceAPI = () => {
-  const { ipcRenderer } = electronAPI;
-
-  const subscribe = (listener: (state: AppearanceState) => void) => {
-    const handler = (_event: unknown, state: AppearanceState) => listener(state);
-    ipcRenderer.on(APPEARANCE_CHANNEL, handler);
-    return () => ipcRenderer.removeListener(APPEARANCE_CHANNEL, handler);
-  };
-
-  return {
-    getState: () => ipcRenderer.invoke('appearance:get-state') as Promise<AppearanceState>,
-    setThemeSource: (themeSource: ThemeSource) =>
-      ipcRenderer.invoke('appearance:set-theme-source', themeSource),
-    subscribe,
-  };
-};
+import { buildAppearanceAPI } from '../__extensions/appearance/preload';
+import { buildPersistenceAPI } from '../__extensions/persistence/preload';
 
 // Custom APIs for renderer
 const api = {
   appearance: buildAppearanceAPI(),
+  persistence: buildPersistenceAPI(),
 };
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/packages/gui-kitchen-sink/gui/App.tsx
+++ b/packages/gui-kitchen-sink/gui/App.tsx
@@ -95,7 +95,12 @@ const Section: React.FC<SectionProps> = ({ title, description, icon, children })
 );
 
 const App: React.FC = () => {
-  const [setting, updateSetting] = useSetting(Setting.default());
+  const [setting, updateSetting] = useSetting(Setting.default(), {
+    persistence: {
+      key: Setting.storageKey,
+      guard: Setting.guard,
+    },
+  });
   const {
     projectName,
     selectedFramework,

--- a/packages/gui-kitchen-sink/gui/App.tsx
+++ b/packages/gui-kitchen-sink/gui/App.tsx
@@ -1,19 +1,6 @@
 import React from 'react';
 
 import type { Key } from '@react-types/shared';
-import Add from '@spectrum-icons/workflow/Add';
-import CCLibrary from '@spectrum-icons/workflow/CCLibrary';
-import Data from '@spectrum-icons/workflow/Data';
-import Delete from '@spectrum-icons/workflow/Delete';
-import FileCode from '@spectrum-icons/workflow/FileCode';
-import FileJson from '@spectrum-icons/workflow/FileJson';
-import FormIcon from '@spectrum-icons/workflow/Form';
-import ModernGridView from '@spectrum-icons/workflow/ModernGridView';
-import SaveFloppy from '@spectrum-icons/workflow/SaveFloppy';
-import UploadToCloud from '@spectrum-icons/workflow/UploadToCloud';
-import ViewCard from '@spectrum-icons/workflow/ViewCard';
-import ViewColumn from '@spectrum-icons/workflow/ViewColumn';
-import ViewDay from '@spectrum-icons/workflow/ViewDay';
 
 import {
   ActionButton,
@@ -48,7 +35,13 @@ import {
   View,
   Well,
   useFileSelection,
+  useSetting,
 } from '@toolbox/design-system';
+
+import { Framework, Plan } from '../src/models/Project';
+
+import { LayoutType, Setting } from './Setting';
+import * as Icon from './components/icons';
 
 const members = [
   { id: 1, name: 'Alice Johnson', role: 'Product Manager', experience: 8 },
@@ -74,15 +67,10 @@ const layouts: Array<{
   label: string;
   icon: () => React.ReactNode;
 }> = [
-  { id: 'dashboard', label: 'Dashboard', icon: () => <ViewCard size="S" /> },
-  { id: 'timeline', label: 'Timeline', icon: () => <ViewDay size="S" /> },
-  { id: 'board', label: 'Board', icon: () => <ViewColumn size="S" /> },
+  { id: 'dashboard', label: 'Dashboard', icon: () => <Icon.ViewCard size="S" /> },
+  { id: 'timeline', label: 'Timeline', icon: () => <Icon.ViewDay size="S" /> },
+  { id: 'board', label: 'Board', icon: () => <Icon.ViewColumn size="S" /> },
 ];
-
-const defaultSortDescriptor = {
-  column: 'name',
-  direction: 'ascending',
-} as const;
 
 type SectionProps = {
   title: string;
@@ -107,29 +95,26 @@ const Section: React.FC<SectionProps> = ({ title, description, icon, children })
 );
 
 const App: React.FC = () => {
-  const [projectName, setProjectName] = React.useState('Next-gen Collaboration Suite');
-  const [memberCount, setMemberCount] = React.useState(12);
-  const [selectedFramework, setSelectedFramework] = React.useState<Key>('react');
-  const [selectedPlan, setSelectedPlan] = React.useState('team');
-  const [isPublished, setIsPublished] = React.useState(true);
-  const [activeLayout, setActiveLayout] = React.useState('dashboard');
+  const [setting, updateSetting] = useSetting(Setting.default());
+  const {
+    projectName,
+    selectedFramework,
+    memberCount,
+    selectedPlan,
+    isPublished,
+    activeLayout,
+    sortMemberDescriptor,
+  } = setting;
+
   const [droppedFiles, setDroppedFiles] = React.useState<DropZoneFileContent[]>([]);
-
-  const { sortDescriptor, onSortChange } = TableViewUtil.usePropsToSort(defaultSortDescriptor);
-
-  const handleFrameworkChange = React.useCallback((key: Key | null) => {
-    if (key != null) {
-      setSelectedFramework(key);
-    }
-  }, []);
 
   const sortedMembers = React.useMemo(
     () =>
       TableViewUtil.toSorted({
         items: members,
-        sortDescriptor,
+        sortDescriptor: sortMemberDescriptor,
       }),
-    [sortDescriptor]
+    [sortMemberDescriptor]
   );
 
   const showToast = React.useCallback(
@@ -169,7 +154,7 @@ const App: React.FC = () => {
   return (
     <Page>
       <Flex alignItems="center" gap="size-125">
-        <CCLibrary size="L" />
+        <Icon.CCLibrary size="L" />
         <Heading level={1}>Design System Kitchen Sink</Heading>
       </Flex>
       <View marginTop="size-150">
@@ -178,25 +163,25 @@ const App: React.FC = () => {
       <Divider marginTop="size-250" />
 
       <Section
-        icon={<SaveFloppy size="M" />}
+        icon={<Icon.SaveFloppy size="M" />}
         title="Actions"
         description="Typical buttons and toast notifications."
       >
         <Flex gap="size-150" wrap alignItems="center">
           <Button variant="accent" onPress={showToast('positive')}>
-            <SaveFloppy slot="icon" />
+            <Icon.SaveFloppy slot="icon" />
             Save
           </Button>
           <Button variant="secondary" onPress={showToast('info')}>
-            <Add slot="icon" />
+            <Icon.Add slot="icon" />
             Save draft
           </Button>
           <Button variant="negative" onPress={showToast('negative')}>
-            <Delete slot="icon" />
+            <Icon.Delete slot="icon" />
             Delete
           </Button>
           <ActionButton onPress={() => Toast.info(`Active layout: ${activeLayout}`)}>
-            <ModernGridView slot="icon" />
+            <Icon.ModernGridView slot="icon" />
             Show layout
           </ActionButton>
           <FileTrigger
@@ -214,7 +199,7 @@ const App: React.FC = () => {
       <Divider marginTop="size-350" />
 
       <Section
-        icon={<FormIcon size="M" />}
+        icon={<Icon.FormIcon size="M" />}
         title="Forms"
         description="A compact mix of common inputs."
       >
@@ -222,19 +207,19 @@ const App: React.FC = () => {
           <TextField
             label="Project name"
             value={projectName}
-            onChange={setProjectName}
+            onChange={updateSetting('projectName')}
             isRequired
           />
           <NumberField
             label="Team size"
             value={memberCount}
-            onChange={setMemberCount}
+            onChange={updateSetting('memberCount')}
             minValue={1}
           />
           <Picker
             label="Frontend framework"
             selectedKey={selectedFramework}
-            onSelectionChange={handleFrameworkChange}
+            onSelectionChange={updateSetting('selectedFramework', Framework.guard)}
           >
             {frameworks.map((framework) => (
               <PickerItem key={framework.id}>{framework.label}</PickerItem>
@@ -243,7 +228,7 @@ const App: React.FC = () => {
           <RadioGroup
             label="Pricing plan"
             value={selectedPlan}
-            onChange={setSelectedPlan}
+            onChange={updateSetting('selectedPlan', Plan.guard)}
             orientation="horizontal"
           >
             {plans.map((plan) => (
@@ -260,7 +245,7 @@ const App: React.FC = () => {
           <Switch
             aria-labelledby={publishLabelId}
             isSelected={isPublished}
-            onChange={setIsPublished}
+            onChange={updateSetting('isPublished')}
           >
             Enabled
           </Switch>
@@ -270,7 +255,7 @@ const App: React.FC = () => {
       <Divider marginTop="size-350" />
 
       <Section
-        icon={<ModernGridView size="M" />}
+        icon={<Icon.ModernGridView size="M" />}
         title="Layouts"
         description="ActionGroup-driven layout switching."
       >
@@ -278,7 +263,7 @@ const App: React.FC = () => {
           <ActionGroup
             selectionMode="single"
             selectedKeys={selectedLayoutKeys}
-            onAction={(key) => setActiveLayout(String(key))}
+            onAction={updateSetting('activeLayout', LayoutType.guard)}
             aria-label="Choose layout"
           >
             {layouts.map((layout) => (
@@ -299,14 +284,14 @@ const App: React.FC = () => {
       <Divider marginTop="size-350" />
 
       <Section
-        icon={<Data size="M" />}
+        icon={<Icon.Data size="M" />}
         title="Table"
         description="Sortable TableView with team data."
       >
         <TableView
           aria-label="Team roster"
-          sortDescriptor={sortDescriptor}
-          onSortChange={onSortChange}
+          sortDescriptor={sortMemberDescriptor}
+          onSortChange={updateSetting('sortMemberDescriptor')}
           width="100%"
         >
           <TableHeader>
@@ -335,14 +320,14 @@ const App: React.FC = () => {
       <Divider marginTop="size-350" />
 
       <Section
-        icon={<UploadToCloud size="M" />}
+        icon={<Icon.UploadToCloud size="M" />}
         title="Drop zone"
         description="DropZone, FileTrigger, and custom hook working together."
       >
         <DropZone onDrop={handleDrop}>
           <View padding="size-200">
             <Flex direction="column" alignItems="center" gap="size-100">
-              <FileJson size="XXL" />
+              <Icon.FileJson size="XXL" />
               <Heading level={3}>Drop files here</Heading>
               <Text>…or pick files with the button below.</Text>
               <Content>
@@ -362,7 +347,7 @@ const App: React.FC = () => {
               {filePreviews.map((file) => (
                 <Well key={file.path}>
                   <Flex alignItems="center" gap="size-100">
-                    <FileCode size="S" />
+                    <Icon.FileCode size="S" />
                     <Heading level={4}>{file.path}</Heading>
                   </Flex>
                   <View

--- a/packages/gui-kitchen-sink/gui/App.tsx
+++ b/packages/gui-kitchen-sink/gui/App.tsx
@@ -96,10 +96,7 @@ const Section: React.FC<SectionProps> = ({ title, description, icon, children })
 
 const App: React.FC = () => {
   const [setting, updateSetting] = useSetting(Setting.default(), {
-    persistence: {
-      key: Setting.storageKey,
-      guard: Setting.guard,
-    },
+    persistence: Setting,
   });
   const {
     projectName,

--- a/packages/gui-kitchen-sink/gui/Setting.ts
+++ b/packages/gui-kitchen-sink/gui/Setting.ts
@@ -1,6 +1,8 @@
 import { SortDescriptor } from '@toolbox/design-system';
+import { isRecord } from '@toolbox/design-system/utils/TypeUtils';
 
-import { Project } from '../src/models/Project';
+import { Framework, Plan } from '../src/models/Project';
+import type { Project } from '../src/models/Project';
 
 export type Setting = Project & {
   activeLayout: LayoutType;
@@ -12,7 +14,10 @@ export const LayoutType = {
   guard: (x: unknown): x is LayoutType => ['dashboard', 'timeline', 'board'].includes(x as string),
 };
 
+const STORAGE_KEY = 'gui-kitchen-sink';
+
 export const Setting = {
+  storageKey: STORAGE_KEY,
   default: (): Setting => ({
     projectName: '',
     memberCount: 0,
@@ -23,4 +28,47 @@ export const Setting = {
     activeLayout: 'dashboard',
     sortMemberDescriptor: SortDescriptor.default(),
   }),
+  guard: (value: unknown): value is Setting => {
+    if (!isRecord(value)) {
+      return false;
+    }
+
+    if ('projectName' in value && typeof value.projectName !== 'string') {
+      return false;
+    }
+
+    if ('memberCount' in value && typeof value.memberCount !== 'number') {
+      return false;
+    }
+
+    if (
+      'selectedFramework' in value &&
+      value.selectedFramework !== undefined &&
+      !Framework.guard(value.selectedFramework)
+    ) {
+      return false;
+    }
+
+    if (
+      'selectedPlan' in value &&
+      value.selectedPlan !== undefined &&
+      !Plan.guard(value.selectedPlan)
+    ) {
+      return false;
+    }
+
+    if ('isPublished' in value && typeof value.isPublished !== 'boolean') {
+      return false;
+    }
+
+    if ('activeLayout' in value && !LayoutType.guard(value.activeLayout)) {
+      return false;
+    }
+
+    if ('sortMemberDescriptor' in value && !SortDescriptor.guard(value.sortMemberDescriptor)) {
+      return false;
+    }
+
+    return true;
+  },
 };

--- a/packages/gui-kitchen-sink/gui/Setting.ts
+++ b/packages/gui-kitchen-sink/gui/Setting.ts
@@ -1,0 +1,26 @@
+import { SortDescriptor } from '@toolbox/design-system';
+
+import { Project } from '../src/models/Project';
+
+export type Setting = Project & {
+  activeLayout: LayoutType;
+  sortMemberDescriptor: SortDescriptor;
+};
+
+export type LayoutType = 'dashboard' | 'timeline' | 'board';
+export const LayoutType = {
+  guard: (x: unknown): x is LayoutType => ['dashboard', 'timeline', 'board'].includes(x as string),
+};
+
+export const Setting = {
+  default: (): Setting => ({
+    projectName: '',
+    memberCount: 0,
+    selectedFramework: undefined,
+    selectedPlan: undefined,
+    isPublished: false,
+
+    activeLayout: 'dashboard',
+    sortMemberDescriptor: SortDescriptor.default(),
+  }),
+};

--- a/packages/gui-kitchen-sink/gui/components/icons.ts
+++ b/packages/gui-kitchen-sink/gui/components/icons.ts
@@ -1,0 +1,13 @@
+export { default as Add } from '@spectrum-icons/workflow/Add';
+export { default as CCLibrary } from '@spectrum-icons/workflow/CCLibrary';
+export { default as Data } from '@spectrum-icons/workflow/Data';
+export { default as Delete } from '@spectrum-icons/workflow/Delete';
+export { default as FileCode } from '@spectrum-icons/workflow/FileCode';
+export { default as FileJson } from '@spectrum-icons/workflow/FileJson';
+export { default as FormIcon } from '@spectrum-icons/workflow/Form';
+export { default as ModernGridView } from '@spectrum-icons/workflow/ModernGridView';
+export { default as SaveFloppy } from '@spectrum-icons/workflow/SaveFloppy';
+export { default as UploadToCloud } from '@spectrum-icons/workflow/UploadToCloud';
+export { default as ViewCard } from '@spectrum-icons/workflow/ViewCard';
+export { default as ViewColumn } from '@spectrum-icons/workflow/ViewColumn';
+export { default as ViewDay } from '@spectrum-icons/workflow/ViewDay';

--- a/packages/gui-kitchen-sink/src/models/Project.ts
+++ b/packages/gui-kitchen-sink/src/models/Project.ts
@@ -1,0 +1,17 @@
+export type Framework = 'react' | 'svelte' | 'vue';
+export const Framework = {
+  guard: (x: unknown): x is Framework => ['react', 'svelte', 'vue'].includes(x as string),
+};
+
+export type Plan = 'starter' | 'team' | 'enterprise';
+export const Plan = {
+  guard: (x: unknown): x is Plan => ['starter', 'team', 'enterprise'].includes(x as string),
+};
+
+export type Project = {
+  projectName: string;
+  memberCount: number;
+  selectedFramework: Framework | undefined;
+  selectedPlan: Plan | undefined;
+  isPublished: boolean;
+};


### PR DESCRIPTION
feat: 永続化APIとuseSettingの整理

- Electron 側に persistence 拡張を追加し、永続化 API とチャネル定数を src/__extensions/persistence に集約
- プリロードで api.persistence を公開し、Kitchen Sink が永続設定を保存・復元できるよう実装
- useSetting を永続化対応に拡張（ホワイトリスト方式・オーバーロードで Required 初期値を強制）